### PR TITLE
Fix for GHC 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 # Stack uses this directory as scratch space.
 /.stack-work/
-# Stack generates the Cabal file from `package.yaml` through hpack.
-/*.cabal

--- a/monad-validate.cabal
+++ b/monad-validate.cabal
@@ -1,0 +1,140 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           monad-validate
+version:        1.2.0.0
+synopsis:       A monad transformer for data validation.
+description:    Provides the 'ValidateT' monad transformer, designed for writing data validations that provide
+                high-quality error reporting without much effort. 'ValidateT' automatically exploits the data
+                dependencies of your program—as encoded implicitly in uses of 'fmap', '<*>', and '>>='—to report
+                as many errors as possible upon failure instead of completely aborting at the first one. See
+                "Control.Monad.Validate" for more information.
+category:       Control
+homepage:       https://github.com/hasura/monad-validate#readme
+bug-reports:    https://github.com/hasura/monad-validate/issues
+author:         Alexis King <lexi.lambda@gmail.com>
+maintainer:     Alexis King <lexi.lambda@gmail.com>
+copyright:      2019 Hasura
+license:        ISC
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    CHANGELOG.md
+    LICENSE
+    package.yaml
+    README.md
+    stack.yaml
+
+source-repository head
+  type: git
+  location: https://github.com/hasura/monad-validate
+
+library
+  exposed-modules:
+      Control.Monad.Validate
+      Control.Monad.Validate.Class
+      Control.Monad.Validate.Internal
+  other-modules:
+      Paths_monad_validate
+  hs-source-dirs:
+      src
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingVia
+      EmptyCase
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeApplications
+      TypeFamilies
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  build-depends:
+      base >=4.12 && <5
+    , exceptions >=0.9 && <1
+    , monad-control ==1.*
+    , mtl
+    , transformers >=0.5.6
+    , transformers-base <1
+  default-language: Haskell2010
+
+test-suite monad-validate-test-suite
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Control.Monad.ValidateSpec
+      Paths_monad_validate
+  hs-source-dirs:
+      test
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingVia
+      EmptyCase
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeApplications
+      TypeFamilies
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -rtsopts -threaded -with-rtsopts=-N
+  build-depends:
+      aeson
+    , aeson-qq
+    , base >=4.12 && <5
+    , exceptions >=0.9 && <1
+    , hspec
+    , monad-control ==1.*
+    , monad-validate
+    , mtl
+    , scientific
+    , text
+    , transformers >=0.5.6
+    , transformers-base <1
+    , unordered-containers
+    , vector
+  default-language: Haskell2010

--- a/src/Control/Monad/Validate/Internal.hs
+++ b/src/Control/Monad/Validate/Internal.hs
@@ -296,7 +296,7 @@ instance (Monad m) => Applicative (ValidateT e m) where
   {-# INLINABLE (<*>) #-}
 
 instance (Monad m) => Monad (ValidateT e m) where
-  ValidateT x >>= f = ValidateT (x >>= (getValidateT . f))
+  ValidateT x >>= f = ValidateT (x >>= \a -> getValidateT (f a))
   {-# INLINE (>>=) #-}
 
 instance MonadTrans (ValidateT e) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,1 @@
-resolver: lts-13.30
-packages: [.]
-extra-deps: []
-flags: {}
+resolver: nightly-2021-09-30

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2021-09-30
+resolver: lts-19.2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 582734
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/9/30.yaml
-    sha256: 86cb05be830b2b1c3a518b4f867a26c47d4213a74c76544e46529aba08aaafae
-  original: nightly-2021-09-30
+    size: 617368
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/2.yaml
+    sha256: e7e57649a12f6178d1158e4b6f1f1885ed56d210ae6174385271cecc9b1ea974
+  original: lts-19.2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 500539
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/30.yaml
-    sha256: 59ad6b944c9903847fecdc1d4815e8500c1f9999d80fd1b4d2d66e408faec44b
-  original: lts-13.30
+    size: 582734
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/9/30.yaml
+    sha256: 86cb05be830b2b1c3a518b4f867a26c47d4213a74c76544e46529aba08aaafae
+  original: nightly-2021-09-30


### PR DESCRIPTION
GHC 9 implements simplified subsumption which requires programs to eta-expand in some cases.

See the [release notes](https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/9.0.1-notes.html#language) for more info (bullet point that starts "GHC now implements simplified subsumption")

Also committing the Cabal file: https://github.com/commercialhaskell/stack/issues/5210